### PR TITLE
CMake: fix install call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ add_subdirectory(cli-server)
 if(gRPC_FOUND)
    install(TARGETS odc-grpc-server odc-grpc-client RUNTIME DESTINATION bin)
 endif()
-install(TARGETS odc_core_lib RUNTIME DESTINATION lib)
+install(TARGETS odc_core_lib LIBRARY DESTINATION lib)
 install(TARGETS odc-cli-server RUNTIME DESTINATION bin)
 
 # Daemon config


### PR DESCRIPTION
Without this cmake 3.13.4 complains:
```
CMake Error at CMakeLists.txt:79 (install):
  install TARGETS given no LIBRARY DESTINATION for shared library target
  "odc_core_lib".
```