### PR TITLE
core: Add missing header <iomanip>

### DIFF
--- a/core/src/CmdsFile.cpp
+++ b/core/src/CmdsFile.cpp
@@ -6,6 +6,7 @@
 #include "CmdsFile.h"
 // STD
 #include <fstream>
+#include <iomanip>
 #include <sstream>
 
 using namespace std;


### PR DESCRIPTION
With `gcc (GCC) 11.1.1 20210428 (Red Hat 11.1.1-1)`:

```console
/home/dklein/projects/ODC/core/src/CmdsFile.cpp: In static member function ‘static std::vector<std::__cxx11::basic_string<char> > odc::core::CCmdsFile::getCmds(const string&)’:
/home/dklein/projects/ODC/core/src/CmdsFile.cpp:20:50: error: ‘quoted’ was not declared in this scope
   20 |         ss << "Failed to open commands file " << quoted(_filepath);
      |                                                  ^~~~~~
```

see https://en.cppreference.com/w/cpp/io/manip/quoted