### PR TITLE
Fix deadlocks in Topology dtor

### DIFF
--- a/examples/src/processor.cpp
+++ b/examples/src/processor.cpp
@@ -8,7 +8,9 @@
 
 #include <fairmq/Device.h>
 #include <fairmq/runDevice.h>
+#include <fairlogger/Logger.h>
 
+#include <cstdlib>
 #include <string>
 
 namespace bpo = boost::program_options;
@@ -18,6 +20,20 @@ struct Processor : fair::mq::Device
     Processor()
     {
         OnData("data1", &Processor::HandleData);
+    }
+
+    void Init() override
+    {
+        GetConfig()->SetProperty<std::string>("crash", "no");
+        GetConfig()->SubscribeAsString("device",
+                                       [](auto key, auto value)
+                                       {
+                                           if (key == "crash" && value == "yes")
+                                           {
+                                               LOG(warn) << "<<< CRASH >>>";
+                                               std::abort();
+                                           }
+                                       });
     }
 
     bool HandleData(FairMQMessagePtr& msg, int)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,18 +70,22 @@ odc_add_boost_tests(SUITE odc_fairmq_lib
   topology/change_state_full_device_lifecycle2
   topology/construction
   topology/construction2
+  topology/device_crashed
   topology/get_properties
   topology/mixed_state
   topology/set_and_get_properties
   topology/set_properties
   topology/set_properties_mixed
+  topology/underlying_session_terminated
   topology/wait_for_state_full_device_lifecycle
-  
+
   DEPS odc_core_lib
 
   EXTRA_ARGS -- --topo-file ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_DATADIR}/odc_fairmq_lib-tests-topo.xml
   PROPERTIES TIMEOUT 10 ENVIRONMENT "${TEST_ENV}"
 )
+set_tests_properties(odc_fairmq_lib::topology/device_crashed PROPERTIES TIMEOUT 45)
+set_tests_properties(odc_fairmq_lib::topology/underlying_session_terminated PROPERTIES TIMEOUT 45)
 odc_add_boost_tests(SUITE odc_custom_commands_lib
   TESTS
   format/construction


### PR DESCRIPTION
by
* monitoring task done events,
* monitoring if the underlying session is still running, and
* as a last resort wait for a hard-coded duration of 30 seconds

fixes #20