### PR TITLE
Fill FailedDevice also on operation timeout 

### DIFF
--- a/fairmq/commands/src/CustomCommands.cpp
+++ b/fairmq/commands/src/CustomCommands.cpp
@@ -336,6 +336,7 @@ namespace odc::cc
                     auto props = fbb.CreateVector(propsVector);
                     cmdBuilder = make_unique<FBCommandBuilder>(fbb);
                     cmdBuilder->add_device_id(deviceId);
+                    cmdBuilder->add_task_id(_cmd.GetTaskId());
                     cmdBuilder->add_request_id(_cmd.GetRequestId());
                     cmdBuilder->add_result(GetFBResult(_cmd.GetResult()));
                     cmdBuilder->add_properties(props);
@@ -347,6 +348,7 @@ namespace odc::cc
                     auto deviceId = fbb.CreateString(_cmd.GetDeviceId());
                     cmdBuilder = make_unique<FBCommandBuilder>(fbb);
                     cmdBuilder->add_device_id(deviceId);
+                    cmdBuilder->add_task_id(_cmd.GetTaskId());
                     cmdBuilder->add_request_id(_cmd.GetRequestId());
                     cmdBuilder->add_result(GetFBResult(_cmd.GetResult()));
                 }
@@ -487,12 +489,12 @@ namespace odc::cc
                         properties.emplace_back(props->Get(j)->key()->str(), props->Get(j)->value()->str());
                     }
                     fCmds.emplace_back(make<Properties>(
-                        cmdPtr.device_id()->str(), cmdPtr.request_id(), GetResult(cmdPtr.result()), properties));
+                        cmdPtr.device_id()->str(), cmdPtr.task_id(), cmdPtr.request_id(), GetResult(cmdPtr.result()), properties));
                 }
                 break;
                 case FBCmd_properties_set:
                     fCmds.emplace_back(make<PropertiesSet>(
-                        cmdPtr.device_id()->str(), cmdPtr.request_id(), GetResult(cmdPtr.result())));
+                        cmdPtr.device_id()->str(), cmdPtr.task_id(), cmdPtr.request_id(), GetResult(cmdPtr.result())));
                     break;
                 default:
                     throw CommandFormatError("unrecognized command type given to odc::cc::Cmds::Deserialize()");

--- a/fairmq/commands/src/CustomCommands.h
+++ b/fairmq/commands/src/CustomCommands.h
@@ -51,8 +51,8 @@ namespace odc::cc
         state_change_subscription,   // args: { device_id, task_id, Result }
         state_change_unsubscription, // args: { device_id, task_id, Result }
         state_change,                // args: { device_id, task_id, last_state, current_state }
-        properties,                  // args: { device_id, request_id, Result, properties }
-        properties_set               // args: { device_id, request_id, Result }
+        properties,                  // args: { device_id, task_id, request_id, Result, properties }
+        properties_set               // args: { device_id, task_id, request_id, Result }
     };
 
     struct Cmd
@@ -495,11 +495,13 @@ namespace odc::cc
     struct Properties : Cmd
     {
         Properties(std::string deviceId,
+                   const uint64_t taskId,
                    std::size_t requestId,
                    const Result result,
                    std::vector<std::pair<std::string, std::string>> properties)
             : Cmd(Type::properties)
             , fDeviceId(std::move(deviceId))
+            , fTaskId(taskId)
             , fRequestId(requestId)
             , fResult(result)
             , fProperties(std::move(properties))
@@ -513,6 +515,14 @@ namespace odc::cc
         auto SetDeviceId(std::string deviceId) -> void
         {
             fDeviceId = std::move(deviceId);
+        }
+        uint64_t GetTaskId() const
+        {
+            return fTaskId;
+        }
+        void SetTaskId(const uint64_t taskId)
+        {
+            fTaskId = taskId;
         }
         auto GetRequestId() const -> std::size_t
         {
@@ -541,6 +551,7 @@ namespace odc::cc
 
       private:
         std::string fDeviceId;
+        uint64_t fTaskId;
         std::size_t fRequestId;
         Result fResult;
         std::vector<std::pair<std::string, std::string>> fProperties;
@@ -548,9 +559,10 @@ namespace odc::cc
 
     struct PropertiesSet : Cmd
     {
-        PropertiesSet(std::string deviceId, std::size_t requestId, Result result)
+        PropertiesSet(std::string deviceId, const uint64_t taskId, std::size_t requestId, Result result)
             : Cmd(Type::properties_set)
             , fDeviceId(std::move(deviceId))
+            , fTaskId(taskId)
             , fRequestId(requestId)
             , fResult(result)
         {
@@ -563,6 +575,14 @@ namespace odc::cc
         auto SetDeviceId(std::string deviceId) -> void
         {
             fDeviceId = std::move(deviceId);
+        }
+        uint64_t GetTaskId() const
+        {
+            return fTaskId;
+        }
+        void SetTaskId(const uint64_t taskId)
+        {
+            fTaskId = taskId;
         }
         auto GetRequestId() const -> std::size_t
         {
@@ -583,6 +603,7 @@ namespace odc::cc
 
       private:
         std::string fDeviceId;
+        uint64_t fTaskId;
         std::size_t fRequestId;
         Result fResult;
     };

--- a/fairmq/commands/src/CustomCommandsFormat.fbs
+++ b/fairmq/commands/src/CustomCommandsFormat.fbs
@@ -61,8 +61,8 @@ enum FBCmd:byte {
     state_change_subscription,     // args: { device_id, task_id, Result }
     state_change_unsubscription,   // args: { device_id, task_id, Result }
     state_change,                  // args: { device_id, task_id, last_state, current_state }
-    properties,                    // args: { device_id, request_id, Result, properties }
-    properties_set                 // args: { device_id, request_id, Result }
+    properties,                    // args: { device_id, task_id, request_id, Result, properties }
+    properties_set                 // args: { device_id, task_id, request_id, Result }
 }
 
 table FBCommand {

--- a/fairmq/plugin/src/ODC.cpp
+++ b/fairmq/plugin/src/ODC.cpp
@@ -539,7 +539,7 @@ namespace odc::plugins
                     LOG(warn) << "Getting properties (request id: " << request_id << ") failed: " << e.what();
                     result = Result::Failure;
                 }
-                Cmds const outCmds(make<cc::Properties>(id, request_id, result, props));
+                Cmds const outCmds(make<cc::Properties>(id, fDDSTaskId, request_id, result, props));
                 fDDS.Send(outCmds.Serialize(), to_string(senderId));
             }
             break;
@@ -563,7 +563,7 @@ namespace odc::plugins
                     LOG(warn) << "Setting properties (request id: " << request_id << ") failed: " << e.what();
                     result = Result::Failure;
                 }
-                Cmds const outCmds(make<PropertiesSet>(id, request_id, result));
+                Cmds const outCmds(make<PropertiesSet>(id, fDDSTaskId, request_id, result));
                 fDDS.Send(outCmds.Serialize(), to_string(senderId));
             }
             break;

--- a/tests/src/odc_custom_commands_lib-tests.cpp
+++ b/tests/src/odc_custom_commands_lib-tests.cpp
@@ -40,8 +40,8 @@ BOOST_AUTO_TEST_CASE(construction)
     Cmds stateChangeSubscriptionCmds(make<StateChangeSubscription>("somedeviceid", 123456, Result::Ok));
     Cmds stateChangeUnsubscriptionCmds(make<StateChangeUnsubscription>("somedeviceid", 123456, Result::Ok));
     Cmds stateChangeCmds(make<StateChange>("somedeviceid", 123456, State::Running, State::Ready));
-    Cmds propertiesCmds(make<Properties>("somedeviceid", 66, Result::Ok, props));
-    Cmds propertiesSetCmds(make<PropertiesSet>("somedeviceid", 42, Result::Ok));
+    Cmds propertiesCmds(make<Properties>("somedeviceid", 123456, 66, Result::Ok, props));
+    Cmds propertiesSetCmds(make<PropertiesSet>("somedeviceid", 123456, 42, Result::Ok));
 
     BOOST_TEST(checkStateCmds.At(0).GetType() == Type::check_state);
     BOOST_TEST(changeStateCmds.At(0).GetType() == Type::change_state);
@@ -88,11 +88,13 @@ BOOST_AUTO_TEST_CASE(construction)
     BOOST_TEST(static_cast<StateChange&>(stateChangeCmds.At(0)).GetCurrentState() == State::Ready);
     BOOST_TEST(propertiesCmds.At(0).GetType() == Type::properties);
     BOOST_TEST(static_cast<Properties&>(propertiesCmds.At(0)).GetDeviceId() == "somedeviceid");
+    BOOST_TEST(static_cast<Properties&>(propertiesCmds.At(0)).GetTaskId() == 123456);
     BOOST_TEST(static_cast<Properties&>(propertiesCmds.At(0)).GetRequestId() == 66);
     BOOST_TEST(static_cast<Properties&>(propertiesCmds.At(0)).GetResult() == Result::Ok);
     BOOST_TEST(static_cast<Properties&>(propertiesCmds.At(0)).GetProps() == props);
     BOOST_TEST(propertiesSetCmds.At(0).GetType() == Type::properties_set);
     BOOST_TEST(static_cast<PropertiesSet&>(propertiesSetCmds.At(0)).GetDeviceId() == "somedeviceid");
+    BOOST_TEST(static_cast<Properties&>(propertiesSetCmds.At(0)).GetTaskId() == 123456);
     BOOST_TEST(static_cast<PropertiesSet&>(propertiesSetCmds.At(0)).GetRequestId() == 42);
     BOOST_TEST(static_cast<PropertiesSet&>(propertiesSetCmds.At(0)).GetResult() == Result::Ok);
 }
@@ -116,8 +118,8 @@ void fillCommands(Cmds& cmds)
     cmds.Add<StateChangeSubscription>("somedeviceid", 123456, Result::Ok);
     cmds.Add<StateChangeUnsubscription>("somedeviceid", 123456, Result::Ok);
     cmds.Add<StateChange>("somedeviceid", 123456, State::Running, State::Ready);
-    cmds.Add<Properties>("somedeviceid", 66, Result::Ok, props);
-    cmds.Add<PropertiesSet>("somedeviceid", 42, Result::Ok);
+    cmds.Add<Properties>("somedeviceid", 123456, 66, Result::Ok, props);
+    cmds.Add<PropertiesSet>("somedeviceid", 123456, 42, Result::Ok);
 }
 
 void checkCommands(Cmds& cmds)
@@ -205,6 +207,7 @@ void checkCommands(Cmds& cmds)
             case Type::properties:
                 ++count;
                 BOOST_TEST(static_cast<Properties&>(*cmd).GetDeviceId() == "somedeviceid");
+                BOOST_TEST(static_cast<Properties&>(*cmd).GetTaskId() == 123456);
                 BOOST_TEST(static_cast<Properties&>(*cmd).GetRequestId() == 66);
                 BOOST_TEST(static_cast<Properties&>(*cmd).GetResult() == Result::Ok);
                 BOOST_TEST(static_cast<Properties&>(*cmd).GetProps() == props);
@@ -212,6 +215,7 @@ void checkCommands(Cmds& cmds)
             case Type::properties_set:
                 ++count;
                 BOOST_TEST(static_cast<PropertiesSet&>(*cmd).GetDeviceId() == "somedeviceid");
+                BOOST_TEST(static_cast<PropertiesSet&>(*cmd).GetTaskId() == 123456);
                 BOOST_TEST(static_cast<PropertiesSet&>(*cmd).GetRequestId() == 42);
                 BOOST_TEST(static_cast<PropertiesSet&>(*cmd).GetResult() == Result::Ok);
                 break;


### PR DESCRIPTION
Previously FailedDevice container of SetProperties and GetProperties return value would only be filled by device that return an error for those operations. This PR fills the container also for timed out devices.

Also the content of FailedDevice has been changed from `std::set<DeviceId>` to `std::unordered_set<DDSTask::Id>` to be more useful, since there is no mapping between task ids and device ids available.