### PR TITLE
fix(core): warning: ISO C++11 requires at least one argument for the "..." in a variadic macro

### DIFF
--- a/core/src/Logger.h
+++ b/core/src/Logger.h
@@ -42,7 +42,7 @@
     BOOST_LOG_CHANNEL_SEV(odc::core::CLogger::instance().logger(), toString(partition, ":", run), severity)
 #define OLOG_GET_MACRO(arg1, arg2, arg3, NAME, ...) NAME
 #define OLOG(...) \
-    OLOG_GET_MACRO(__VA_ARGS__, OLOG_SEVERITY_PARTITION_RUN, OLOG_SEVERITY_COMMON, OLOG_SEVERITY)(__VA_ARGS__)
+    OLOG_GET_MACRO(__VA_ARGS__, OLOG_SEVERITY_PARTITION_RUN, OLOG_SEVERITY_COMMON, OLOG_SEVERITY, UNUSED)(__VA_ARGS__)
 
 namespace odc::core
 {


### PR DESCRIPTION
fix #47