### PR TITLE
feat(grpc): Annotate incoming request logs with client info

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ def jobMatrix(String type, List specs) {
           sh "echo \"set -e\" >> ${jobscript}"
           sh "echo \"export LABEL=\\\"\${JOB_BASE_NAME} ${label}\\\"\" >> ${jobscript}"
           if (selector =~ /alice/) {
-            ctestcmd = "aliBuild build --defaults o2 ODC --debug && cd \\\\\\\${ALIBUILD_WORK_DIR}/BUILD/ODC-latest/ODC && alienv setenv ODC/latest,CMake/latest -c ctest --output-on-failure"
+            ctestcmd = "aliBuild build --defaults o2 ODC --debug && cd ODC && alienv setenv ODC/latest,CMake/latest -c ctest -VV -S ODCTest.cmake -DTEST_ONLY=ON -DCTEST_BINARY_DIRECTORY=\\\\\\\${ALIBUILD_WORK_DIR}/BUILD/ODC-latest/ODC"
           }
           def containercmd = "singularity exec -B/shared ${env.SINGULARITY_CONTAINER_ROOT}/odc/${os}.${ver}.sif bash -l -c \\\"${ctestcmd} ${extra}\\\""
           if (selector =~ /alice/) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,7 @@ def jobMatrix(String type, List specs) {
 
 pipeline{
   agent none
+  options { ansiColor('xterm') }
   stages {
     stage("CI") {
       steps{

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -34,7 +34,7 @@ def jobMatrix(String type, List specs) {
           sh "echo \"set -e\" >> ${jobscript}"
           sh "echo \"export LABEL=\\\"\${JOB_BASE_NAME} ${label}\\\"\" >> ${jobscript}"
           if (selector =~ /alice/) {
-            ctestcmd = "aliBuild build --defaults o2 ODC --debug && cd \\\\\\\${ALIBUILD_WORK_DIR}/BUILD/ODC-latest/ODC && alienv setenv ODC/latest,CMake/latest -c ctest --output-on-failure"
+            ctestcmd = "aliBuild build --defaults o2 ODC --debug && cd ODC && alienv setenv ODC/latest,CMake/latest -c ctest -VV -S ODCTest.cmake -DTEST_ONLY=ON -DCTEST_BINARY_DIRECTORY=\\\\\\\${ALIBUILD_WORK_DIR}/BUILD/ODC-latest/ODC"
           }
           def containercmd = "singularity exec -B/shared ${env.SINGULARITY_CONTAINER_ROOT}/odc/${os}.${ver}.sif bash -l -c \\\"${ctestcmd} ${extra}\\\""
           if (selector =~ /alice/) {

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -64,6 +64,7 @@ def jobMatrix(String type, List specs) {
 
 pipeline{
   agent none
+  options { ansiColor('xterm') }
   triggers { cron('H H(0-3) * * *') }
   stages {
     stage("CI") {

--- a/ODCTest.cmake
+++ b/ODCTest.cmake
@@ -8,8 +8,12 @@
 
 cmake_host_system_information(RESULT fqdn QUERY FQDN)
 
-set(CTEST_SOURCE_DIRECTORY .)
-set(CTEST_BINARY_DIRECTORY build)
+if(NOT CTEST_SOURCE_DIRECTORY)
+  set(CTEST_SOURCE_DIRECTORY .)
+endif()
+if(NOT CTEST_BINARY_DIRECTORY)
+  set(CTEST_BINARY_DIRECTORY build)
+endif()
 set(CTEST_CMAKE_GENERATOR "Ninja")
 set(CTEST_USE_LAUNCHERS ON)
 if(CMAKE_CXX_FLAGS)
@@ -49,7 +53,7 @@ else()
   ctest_start(Continuous)
 endif()
 
-
+if(NOT TEST_ONLY)
 list(APPEND options "-DCMAKE_INSTALL_PREFIX=install")
 if(ENABLE_SANITIZERS)
   list(APPEND options "-DCMAKE_CXX_FLAGS='-O1 -fsanitize=address,leak,undefined -fno-omit-frame-pointer -fno-var-tracking-assignments'")
@@ -63,6 +67,7 @@ ctest_submit()
 ctest_build(FLAGS "-j${NCPUS}")
 
 ctest_submit()
+endif()
 
 ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}"
            PARALLEL_LEVEL 1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ install(FILES batch_cmds.cfg DESTINATION ${PROJECT_INSTALL_DATADIR})
 set(target odc-cli-server)
 set(test ${target}::batch_cmds_from_file)
 add_test(NAME ${test} COMMAND $<TARGET_FILE:odc-cli-server> --batch --cf ${CMAKE_CURRENT_SOURCE_DIR}/batch_cmds.cfg)
-set_tests_properties(${test} PROPERTIES TIMEOUT 10 PASS_REGULAR_EXPRESSION "Sleeping 100 ms" ENVIRONMENT "${TEST_ENV}")
+set_tests_properties(${test} PROPERTIES TIMEOUT 60 PASS_REGULAR_EXPRESSION "Sleeping 100 ms" ENVIRONMENT "${TEST_ENV}")
 
 # Test `--script` option of odc-cli-server
 set(ODC_DATADIR "${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_DATADIR}")
@@ -35,7 +35,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/batch_cmds_with_script.cfg DESTINATION
 set(target odc-cli-server)
 set(test ${target}::batch_cmds_from_file_with_script)
 add_test(NAME ${test} COMMAND $<TARGET_FILE:odc-cli-server> --batch --cf ${CMAKE_CURRENT_BINARY_DIR}/batch_cmds_with_script.cfg)
-set_tests_properties(${test} PROPERTIES TIMEOUT 10 FAIL_REGULAR_EXPRESSION "Status code: ERROR" ENVIRONMENT "${TEST_ENV}")
+set_tests_properties(${test} PROPERTIES TIMEOUT 60 FAIL_REGULAR_EXPRESSION "Status code: ERROR" ENVIRONMENT "${TEST_ENV}")
 
 #
 # Boost.UTF tests
@@ -78,10 +78,8 @@ odc_add_boost_tests(SUITE odc
   DEPS ODC::odc
 
   EXTRA_ARGS -- --topo-file ${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_DATADIR}/odc-tests-topo.xml
-  PROPERTIES TIMEOUT 10 ENVIRONMENT "${TEST_ENV}"
+  PROPERTIES TIMEOUT 60 ENVIRONMENT "${TEST_ENV}"
 )
-set_tests_properties(odc::topology/device_crashed PROPERTIES TIMEOUT 45)
-set_tests_properties(odc::topology/underlying_session_terminated PROPERTIES TIMEOUT 45)
 odc_add_boost_tests(SUITE cc
   TESTS
   format/construction
@@ -90,5 +88,5 @@ odc_add_boost_tests(SUITE cc
 
   DEPS ODC::cc
 
-  PROPERTIES TIMEOUT 10 ENVIRONMENT "${TEST_ENV}"
+  PROPERTIES TIMEOUT 60 ENVIRONMENT "${TEST_ENV}"
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,8 @@ else()
   list(APPEND TEST_ENV "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_LIBDIR}:${Boost_LIBRARY_DIRS}:$ENV{LD_LIBRARY_PATH}")
 endif()
 list(APPEND TEST_ENV "PATH=${CMAKE_INSTALL_PREFIX}/${PROJECT_INSTALL_BINDIR}:$ENV{PATH}")
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/tmp")
+list(APPEND TEST_ENV "TMPDIR=${CMAKE_BINARY_DIR}/tmp")
 
 # Test odc-cli-server with default set of options
 set(target odc-cli-server)


### PR DESCRIPTION
example for sending init and shutdown requests from two different `odc-grpc-client`s for the same partition `part1`:
```
2022-02-15 17:28:44.665749 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> part1:0              Initialize request from [ipv4:127.0.0.1:60534]{user-agent:grpc-c++/1.39.1 grpc-c/18.0.0 (linux; chttp2)}:
partitionid: "part1"
2022-02-15 17:28:44.805792 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> part1:0              DDS session created with session ID: 6f9f0370-218f-4cfd-b66b-4f4473583e55
2022-02-15 17:28:44.805941 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> part1:0              Subscribed to task done event from session "6f9f0370-218f-4cfd-b66b-4f4473583e55"
2022-02-15 17:28:44.805980 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> part1:0              Initialize response:
msg: "Initialize done"
status: SUCCESS
exectime: 140
partitionid: "part1"
sessionid: "6f9f0370-218f-4cfd-b66b-4f4473583e55"
state: "UNDEFINED"
(...)
2022-02-15 17:28:52.526908 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> part1:0              Shutdown request from [ipv4:127.0.0.1:60536]{user-agent:grpc-c++/1.39.1 grpc-c/18.0.0 (linux; chttp2)}:
partitionid: "part1"
2022-02-15 17:28:53.556358 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> part1:0              DDS session shutted down
2022-02-15 17:28:53.556507 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> part1:0              Shutdown response:
msg: "Shutdown done"
status: SUCCESS
exectime: 1029
partitionid: "part1"
sessionid: "00000000-0000-0000-0000-000000000000"
state: "UNDEFINED"
```

---

For debugging/tracing scenarios it logs arbitrary grpc client metadata key/value pairs, e.g.
```
❯ evans --proto odc/grpc/odc.proto

  ______
 |  ____|
 | |__    __   __   __ _   _ __    ___
 |  __|   \ \ / /  / _. | | '_ \  / __|
 | |____   \ V /  | (_| | | | | | \__ \
 |______|   \_/    \__,_| |_| |_| |___/

 more expressive universal gRPC client

odc.ODC@127.0.0.1:50051> header mytoken=traceme

odc.ODC@127.0.0.1:50051> show header
+-------------+---------+
|     KEY     |   VAL   |
+-------------+---------+
| grpc-client | evans   |
| mytoken     | traceme |
+-------------+---------+

odc.ODC@127.0.0.1:50051> call Initialize
partitionid (TYPE_STRING) => mypart
runnr (TYPE_UINT64) => 42
timeout (TYPE_UINT32) => 30
sessionid (TYPE_STRING) =>
{
  "exectime": 136,
  "msg": "Initialize done",
  "partitionid": "mypart",
  "runnr": "42",
  "sessionid": "daa10e99-88df-40f5-8fcb-2f5b33c5b6d5",
  "state": "UNDEFINED",
  "status": "SUCCESS"
}
```
results in
```
2022-02-15 17:39:30.814963 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> mypart:42            Initialize request from [ipv4:127.0.0.1:60538]{grpc-client:evans,mytoken:traceme,user-agent:grpc-go/1.43.0}:
partitionid: "mypart"
runnr: 42
timeout: 30
2022-02-15 17:39:30.951374 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> mypart:42            DDS session created with session ID: daa10e99-88df-40f5-8fcb-2f5b33c5b6d5
2022-02-15 17:39:30.951518 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> mypart:42            Subscribed to task done event from session "daa10e99-88df-40f5-8fcb-2f5b33c5b6d5"
2022-02-15 17:39:30.951547 inf  odc-grpc-server      <0x0035ede1:0x00007f32e0dfd180> mypart:42            Initialize response:
msg: "Initialize done"
status: SUCCESS
exectime: 136
partitionid: "mypart"
sessionid: "daa10e99-88df-40f5-8fcb-2f5b33c5b6d5"
state: "UNDEFINED"
runnr: 42

```